### PR TITLE
Fetch system font families from root base path

### DIFF
--- a/src/ports/SkFontMgr_android_parser.cpp
+++ b/src/ports/SkFontMgr_android_parser.cpp
@@ -23,14 +23,24 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define LMP_SYSTEM_FONTS_FILE "/system/etc/fonts.xml"
-#define OLD_SYSTEM_FONTS_FILE "/system/etc/system_fonts.xml"
-#define FALLBACK_FONTS_FILE "/system/etc/fallback_fonts.xml"
-#define VENDOR_FONTS_FILE "/vendor/etc/fallback_fonts.xml"
+// #define LMP_SYSTEM_FONTS_FILE "/system/etc/fonts.xml"
+// #define OLD_SYSTEM_FONTS_FILE "/system/etc/system_fonts.xml"
+// #define FALLBACK_FONTS_FILE "/system/etc/fallback_fonts.xml"
+// #define VENDOR_FONTS_FILE "/vendor/etc/fallback_fonts.xml"
+// 
+// #define LOCALE_FALLBACK_FONTS_SYSTEM_DIR "/system/etc"
+// #define LOCALE_FALLBACK_FONTS_VENDOR_DIR "/vendor/etc"
+// #define LOCALE_FALLBACK_FONTS_PREFIX "fallback_fonts-"
+// #define LOCALE_FALLBACK_FONTS_SUFFIX ".xml"
+  
+#define LMP_SYSTEM_FONTS_FILE "/package/etc/fonts.xml"
+#define OLD_SYSTEM_FONTS_FILE "/package/etc/system_fonts.xml"
+#define FALLBACK_FONTS_FILE "/package/etc/fallback_fonts.xml"
+#define VENDOR_FONTS_FILE "/package/etc/fallback_fonts.xml"
 
-#define LOCALE_FALLBACK_FONTS_SYSTEM_DIR "/system/etc"
-#define LOCALE_FALLBACK_FONTS_VENDOR_DIR "/vendor/etc"
-#define LOCALE_FALLBACK_FONTS_PREFIX "fallback_fonts-"
+#define LOCALE_FALLBACK_FONTS_SYSTEM_DIR "/package/etc"
+#define LOCALE_FALLBACK_FONTS_VENDOR_DIR "/package/etc"
+#define LOCALE_FALLBACK_FONTS_PREFIX "fallback_fonts"
 #define LOCALE_FALLBACK_FONTS_SUFFIX ".xml"
 
 #ifndef SK_FONT_FILE_PREFIX

--- a/src/ports/SkFontMgr_android_parser.cpp
+++ b/src/ports/SkFontMgr_android_parser.cpp
@@ -771,8 +771,9 @@ static void mixin_vendor_fallback_font_families(SkTDArray<FontFamily*>& fallback
 
 void SkFontMgr_Android_Parser::GetSystemFontFamilies(SkTDArray<FontFamily*>& fontFamilies) {
     // Version 21 of the system font configuration does not need any fallback configuration files.
-    SkString basePath(getenv("ANDROID_ROOT"));
-    basePath.append(SK_FONT_FILE_PREFIX, sizeof(SK_FONT_FILE_PREFIX) - 1);
+    /* SkString basePath(getenv("ANDROID_ROOT"));
+    basePath.append(SK_FONT_FILE_PREFIX, sizeof(SK_FONT_FILE_PREFIX) - 1); */
+    SkString basePath("/");
 
     if (append_system_font_families(fontFamilies, basePath) >= 21) {
         return;


### PR DESCRIPTION
This is needed for fixing Magic Leap `fonts.xml` fetching, since it uses a custom font path from the root.